### PR TITLE
Faster lambdamart loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+This project is [OpenSource Connections](http://opensourceconnections.com) API-compatible fork or Ranklib, deployed on Maven, with various improvements making it easier to integrate with the [Elasticsearch Learning to Rank Plugin](http://github.com/o19s/elasticsearch-learning-to-rank).
+
+## Ranklib
+
+Ranklib is an open source learning to rank project hosted on [sourceforge](sourceforge.net/p/lemur/wiki/RankLib/) as part of the Lemur project. You can read the latest Ranklib Readme [here](readme.txt).
+
+## Improvements over Ranklib
+
+- Performance improvement reading in models, needed for the [Elasticsearch Learning to Rank Plugin](http://github.com/o19s/elasticsearch-learning-to-rank)

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   
   <groupId>edu.umass.ciir</groupId>
-  <artifactId>RankLib</artifactId>
-  <version>2.10-DOUG</version>
+  <artifactId>RankLibPlus</artifactId>
+  <version>0.1.0</version>
 
   <packaging>jar</packaging>
   <name>RankLib</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   
   <groupId>edu.umass.ciir</groupId>
   <artifactId>RankLib</artifactId>
-  <version>2.9-SNAPSHOT</version>
+  <version>2.10-DOUG</version>
 
   <packaging>jar</packaging>
   <name>RankLib</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   
-  <groupId>edu.umass.ciir</groupId>
+  <groupId>com.o19s</groupId>
   <artifactId>RankLibPlus</artifactId>
   <version>0.1.0</version>
 

--- a/src/ciir/umass/edu/learning/tree/LambdaMART.java
+++ b/src/ciir/umass/edu/learning/tree/LambdaMART.java
@@ -311,23 +311,50 @@ public class LambdaMART extends Ranker {
         @Override
 	public void loadFromString(String fullText)
 	{
+		int CARRIAGE_RETURN = 13;
+		int LINE_FEED = 10;
+
 		try {
 			String content = "";
-			//String model = "";
-			StringBuffer model = new StringBuffer ();
-			BufferedReader in = new BufferedReader(new StringReader(fullText));
-			while((content = in.readLine()) != null)
-			{
-				content = content.trim();
-				if(content.length() == 0)
-					continue;
-				if(content.indexOf("##")==0)
-					continue;
-				//actual model component
-				//model += content;
-				model.append (content);
+			StringBuilder model = new StringBuilder();
+
+			char [] fullTextChar = fullText.toCharArray();
+
+			int lineCursor = 0;
+			for (int i = 0; i < fullTextChar.length; i++) {
+				int charNum = fullTextChar[i];
+				if (charNum == CARRIAGE_RETURN || charNum == LINE_FEED) {
+
+					// NEWLINE, read lineCursor -> i
+					if (fullTextChar[lineCursor] != '#') {
+						for (int j = lineCursor; j < i; j++) {
+							model.append(fullTextChar[j]);
+						}
+					}
+
+					// readahead this new line up to the next space
+					while (charNum < 32 & i < fullTextChar.length) {
+						charNum = fullTextChar[i];
+						lineCursor = i;
+						i++;
+					}
+				}
 			}
-			in.close();
+//
+//			//String model = "";
+//			BufferedReader in = new BufferedReader(new StringReader(fullText));
+//			while((content = in.readLine()) != null)
+//			{
+//				content = content.trim();
+//				if(content.length() == 0)
+//					continue;
+//				if(content.indexOf("##")==0)
+//					continue;
+//				//actual model component
+//				//model += content;
+//				model.append (content);
+//			}
+//			in.close();
 			//load the ensemble
 			ensemble = new Ensemble(model.toString());
 			features = ensemble.getFeatures();

--- a/src/ciir/umass/edu/learning/tree/LambdaMART.java
+++ b/src/ciir/umass/edu/learning/tree/LambdaMART.java
@@ -320,26 +320,39 @@ public class LambdaMART extends Ranker {
 
 			char [] fullTextChar = fullText.toCharArray();
 
-			int lineCursor = 0;
+			int beginOfLineCursor = 0;
 			for (int i = 0; i < fullTextChar.length; i++) {
 				int charNum = fullTextChar[i];
 				if (charNum == CARRIAGE_RETURN || charNum == LINE_FEED) {
 
-					// NEWLINE, read lineCursor -> i
-					if (fullTextChar[lineCursor] != '#') {
-						for (int j = lineCursor; j < i; j++) {
+					// NEWLINE, read beginOfLineCursor -> i
+					if (fullTextChar[beginOfLineCursor] != '#') {
+						int eolCursor = i;
+						while (eolCursor > beginOfLineCursor && fullTextChar[eolCursor] <= 32) {
+							eolCursor--;
+						}
+
+						for (int j = beginOfLineCursor; j <= eolCursor; j++) {
 							model.append(fullTextChar[j]);
 						}
 					}
 
 					// readahead this new line up to the next space
-					while (charNum < 32 & i < fullTextChar.length) {
+					while (charNum <= 32 & i < fullTextChar.length) {
 						charNum = fullTextChar[i];
-						lineCursor = i;
+						beginOfLineCursor = i;
 						i++;
 					}
 				}
 			}
+
+			// read beginOfLineCursor -> EOF
+			if (fullTextChar[beginOfLineCursor] != '#') {
+				for (int j = beginOfLineCursor; j < fullTextChar.length; j++) {
+					model.append(fullTextChar[j]);
+				}
+			}
+
 
 			//load the ensemble
 			ensemble = new Ensemble(model.toString());

--- a/src/ciir/umass/edu/learning/tree/LambdaMART.java
+++ b/src/ciir/umass/edu/learning/tree/LambdaMART.java
@@ -311,23 +311,35 @@ public class LambdaMART extends Ranker {
         @Override
 	public void loadFromString(String fullText)
 	{
+		int CARRIAGE_RETURN = 13;
+		int LINE_FEED = 10;
+
 		try {
 			String content = "";
-			//String model = "";
-			StringBuffer model = new StringBuffer ();
-			BufferedReader in = new BufferedReader(new StringReader(fullText));
-			while((content = in.readLine()) != null)
-			{
-				content = content.trim();
-				if(content.length() == 0)
-					continue;
-				if(content.indexOf("##")==0)
-					continue;
-				//actual model component
-				//model += content;
-				model.append (content);
+			StringBuilder model = new StringBuilder();
+
+			char [] fullTextChar = fullText.toCharArray();
+
+			int lineCursor = 0;
+			for (int i = 0; i < fullTextChar.length; i++) {
+				int charNum = fullTextChar[i];
+				if (charNum == CARRIAGE_RETURN || charNum == LINE_FEED) {
+
+					// NEWLINE, read lineCursor -> i
+					if (fullTextChar[lineCursor] != '#') {
+						for (int j = lineCursor; j < i; j++) {
+							model.append(fullTextChar[j]);
+						}
+					}
+
+					// readahead this new line up to the next space
+					while (charNum < 32 & i < fullTextChar.length) {
+						charNum = fullTextChar[i];
+						lineCursor = i;
+						i++;
+					}
+				}
 			}
-			in.close();
 			//load the ensemble
 			ensemble = new Ensemble(model.toString());
 			features = ensemble.getFeatures();

--- a/test/ciir/umass/edu/eval/EvaluatorTest.java
+++ b/test/ciir/umass/edu/eval/EvaluatorTest.java
@@ -4,6 +4,7 @@ import ciir.umass.edu.learning.CoorAscent;
 import ciir.umass.edu.learning.DataPoint;
 import ciir.umass.edu.learning.Ranker;
 import ciir.umass.edu.learning.RankerFactory;
+import ciir.umass.edu.learning.tree.LambdaMART;
 import ciir.umass.edu.utilities.FileUtils;
 import ciir.umass.edu.utilities.TmpFile;
 import org.junit.Ignore;
@@ -193,6 +194,53 @@ public class EvaluatorTest {
       testRanker(dataFile, modelFile, rankFile, 6, "map");
     }
   }
+
+  @Test
+  public void testLambdaMARTParseModel() throws IOException {
+
+    String simpleModel = "## LambdaMART\n" +
+            "## name:foo\n" +
+            "## No. of trees = 1\n" +
+            "## No. of leaves = 10\n" +
+            "## No. of threshold candidates = 256\n" +
+            "## Learning rate = 0.1\n" +
+            "## Stop early = 100\n" +
+            "\n" +
+            "<ensemble>\n" +
+            " <tree id=\"1\" weight=\"0.1\">\n" +
+            "  <split>\n" +
+            "   <feature> 1 </feature>\n" +
+            "   <threshold> 0.45867884 </threshold>\n" +
+            "   <split pos=\"left\">\n" +
+            "    <feature> 1 </feature>\n" +
+            "    <threshold> 0.0 </threshold>\n" +
+            "    <split pos=\"left\">\n" +
+            "     <output> -2.0 </output>\n" +
+            "    </split>\n" +
+            "    <split pos=\"right\">\n" +
+            "     <output> -1.3413081169128418 </output>\n" +
+            "    </split>\n" +
+            "   </split>\n" +
+            "   <split pos=\"right\">\n" +
+            "    <feature> 1 </feature>\n" +
+            "    <threshold> 0.6115718 </threshold>\n" +
+            "    <split pos=\"left\">\n" +
+            "     <output> 0.3089442849159241 </output>\n" +
+            "    </split>\n" +
+            "    <split pos=\"right\">\n" +
+            "     <output> 2.0 </output>\n" +
+            "    </split>\n" +
+            "   </split>\n" +
+            "  </split>\n" +
+            " </tree>\n" +
+            "</ensemble>";
+
+      RankerFactory factory = new RankerFactory();
+      Ranker ranker = factory.loadRankerFromString(simpleModel);
+      LambdaMART lambdaMART = (LambdaMART)ranker;
+      assert(lambdaMART != null);
+  }
+
   @Test
   public void testListNet() throws IOException {
     try (TmpFile dataFile = new TmpFile();


### PR DESCRIPTION
Related to [Elasticsearch learning to rank plugin](http://github.com/o19s/elasticsearch-learning-to-rank):

- Loading large LambdaMART models was taking a looooong time, which causes the Elasticsearch cluster to get unhappy, often disconnect nodes, and the like
- Turns out there's a lot of Java string heap churn when loading this stuff, just around reading lines and stripping fronting whitespace. 

This PR unrolls a lot of heap-heavy work, makes it fugly C-like code with far fewer heap allocations, and makes it about 100 times faster