### PR TITLE
Report the impact of each feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Ranklib is an open source learning to rank project hosted on [sourceforge](sourc
 ## Improvements over Ranklib
 
 - Performance improvement reading in models, needed for the [Elasticsearch Learning to Rank Plugin](http://github.com/o19s/elasticsearch-learning-to-rank)
+- During training: outputs impact (total error reduced) of each feature

--- a/src/ciir/umass/edu/learning/tree/Split.java
+++ b/src/ciir/umass/edu/learning/tree/Split.java
@@ -159,16 +159,6 @@ public class Split {
 			strOutput += right.getString(indent + "\t");
 			strOutput += indent + "</split>" + "\n";
 		}
-		strOutput += indent + "<psuedoResponse>";
-
-		strOutput += indent + "  <sum>";
-		strOutput += indent + "  " + sumLabel;
-		strOutput += indent + "  </sum>";
-
-		strOutput += indent + "  <sqSum>";
-		strOutput += indent + "  " + sumLabel;
-		strOutput += indent + "  </sqSum>";
-		strOutput += indent + "</psuedoResponse>";
 		return strOutput;
 	}
 

--- a/src/ciir/umass/edu/learning/tree/Split.java
+++ b/src/ciir/umass/edu/learning/tree/Split.java
@@ -28,7 +28,7 @@ public class Split {
 	//Intermediate variables (ONLY used during learning)
 	//*DO NOT* attempt to access them once the training is done
 	private boolean isRoot = false;
-	private double sumLabel = 0.0;
+	private double sumLabel = 0.0;		// label really means the psueodo-response state for lambdamart
 	private double sqSumLabel = 0.0;
 	private Split left = null;
 	private Split right = null;
@@ -159,6 +159,16 @@ public class Split {
 			strOutput += right.getString(indent + "\t");
 			strOutput += indent + "</split>" + "\n";
 		}
+		strOutput += indent + "<psuedoResponse>";
+
+		strOutput += indent + "  <sum>";
+		strOutput += indent + "  " + sumLabel;
+		strOutput += indent + "  </sum>";
+
+		strOutput += indent + "  <sqSum>";
+		strOutput += indent + "  " + sumLabel;
+		strOutput += indent + "  </sqSum>";
+		strOutput += indent + "</psuedoResponse>";
 		return strOutput;
 	}
 

--- a/test/ciir/umass/edu/eval/EvaluatorTest.java
+++ b/test/ciir/umass/edu/eval/EvaluatorTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.*;
 /**
  * @author jfoley.
  */
-public class EvaluatorTest {
+public class EvaluatorTest extends RankyTest {
   @Test
   public void testCLINoArgs() {
     // DataPoint has ugly globals, so for now, make this threadsafe
@@ -344,61 +344,6 @@ public class EvaluatorTest {
     ) {
       writeRandomData(dataFile);
       testRanker(dataFile, modelFile, rankFile, 6, "map");
-    }
-  }
-
-  private void testRanker(TmpFile dataFile, TmpFile modelFile, TmpFile rankFile, int rnum, String measure) {
-    System.err.println("Test Ranker: " + rnum);
-
-    synchronized (DataPoint.class) {
-      Evaluator.main(new String[]{
-          "-train", dataFile.getPath(),
-          "-metric2t", measure,
-          "-ranker", Integer.toString(rnum),
-          "-frate", "1.0",
-          "-bag", "10",
-          "-round", "10",
-          "-epoch", "10",
-          "-save", modelFile.getPath()});
-    }
-
-    synchronized (DataPoint.class) {
-      Evaluator.main(new String[]{
-          "-rank", dataFile.getPath(),
-          "-load", modelFile.getPath(),
-          "-indri", rankFile.getPath()
-      });
-    }
-
-    int pRank = Integer.MAX_VALUE;
-    int nRank = Integer.MAX_VALUE;
-
-    String trecrun = FileUtils.read(rankFile.getPath(), "UTF-8");
-    for (String line : trecrun.split("\n")) {
-      try {
-        String[] row = line.split("\\s+");
-        //assertEquals("x", row[0]); // qid
-        assertEquals("Q0", row[1]); // unused
-        String dname = row[2];
-        int rank = Integer.parseInt(row[3]);
-        double score = Double.parseDouble(row[4]);
-        //assertEquals("ranklib", row[5]);
-
-        assertFalse(Double.isNaN(score));
-        assertTrue(Double.isFinite(score));
-        assert (rank > 0);
-
-        if (dname.startsWith("P")) {
-          pRank = Math.min(rank, pRank);
-        } else {
-          nRank = Math.min(rank, nRank);
-        }
-
-        assertTrue(pRank < nRank);
-        assertEquals(1, pRank);
-      } catch (AssertionError aerr) {
-        throw new RuntimeException(line, aerr);
-      }
     }
   }
 }

--- a/test/ciir/umass/edu/eval/FeatureStrengthTest.java
+++ b/test/ciir/umass/edu/eval/FeatureStrengthTest.java
@@ -1,0 +1,48 @@
+package ciir.umass.edu.eval;
+
+import ciir.umass.edu.utilities.TmpFile;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * Created by doug on 7/1/17.
+ */
+public class FeatureStrengthTest extends RankyTest {
+
+    TmpFile _dataFile;
+    TmpFile _modelFile;
+    TmpFile _rankFile;
+
+    @Before
+    public void setupFiles() throws IOException {
+        _dataFile = new TmpFile();
+        _modelFile = new TmpFile();
+        _rankFile = new TmpFile();
+    }
+
+    void runLambdaMart() {
+        testRanker(_dataFile, _modelFile, _rankFile, 6, "ndcg@4");
+    }
+
+    @Test
+    public void testFeatureStrength() throws IOException {
+        _dataFile = new TmpFile();
+        try (PrintWriter out = _dataFile.getWriter()) {
+            out.println("## LambdaMART ");
+            out.println("4 qid:1 1:100.0 2:1  # P1");
+            out.println("4 qid:1 1:100.0 2:1  # P2 ");
+            out.println("4 qid:1 1:100.0 2:1  # P3");
+            out.println("4 qid:1 1:100.0 2:1  # P4");
+            out.println("0 qid:1 1:0.0 2:1    # P5");
+            out.println("0 qid:1 1:0.0 2:1    # P6");
+            out.println("0 qid:1 1:0.0 2:1    # P7");
+            out.println("0 qid:1 1:0.0 2:1    # P8");
+        }
+        runLambdaMart();
+
+    }
+
+}

--- a/test/ciir/umass/edu/eval/FeatureStrengthTest.java
+++ b/test/ciir/umass/edu/eval/FeatureStrengthTest.java
@@ -4,7 +4,9 @@ import ciir.umass.edu.utilities.TmpFile;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 
 /**
@@ -23,8 +25,14 @@ public class FeatureStrengthTest extends RankyTest {
         _rankFile = new TmpFile();
     }
 
-    void runLambdaMart() {
+    String runLambdaMart(boolean captureStdOut) {
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        if (captureStdOut) {
+            System.setOut(new PrintStream(outContent));
+        }
+
         testRanker(_dataFile, _modelFile, _rankFile, 6, "ndcg@4");
+        return outContent.toString();
     }
 
     @Test
@@ -41,7 +49,10 @@ public class FeatureStrengthTest extends RankyTest {
             out.println("0 qid:1 1:0.0 2:1    # P7");
             out.println("0 qid:1 1:0.0 2:1    # P8");
         }
-        runLambdaMart();
+        String stdOut = runLambdaMart(true);
+        String ftrImpacts = stdOut.substring(stdOut.indexOf("FEATURE IMPACTS"));
+        // we expect "Feature 1" to be a higher impact than feature 2, ensure it comes first
+        assert(ftrImpacts.indexOf("Feature 1") < ftrImpacts.indexOf("Feature 2"));
 
     }
 

--- a/test/ciir/umass/edu/eval/FeatureStrengthTest.java
+++ b/test/ciir/umass/edu/eval/FeatureStrengthTest.java
@@ -25,18 +25,18 @@ public class FeatureStrengthTest extends RankyTest {
         _rankFile = new TmpFile();
     }
 
-    String runLambdaMart(boolean captureStdOut) {
+    String runAndCaptureRanker(int rnum, boolean captureStdOut) {
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         if (captureStdOut) {
             System.setOut(new PrintStream(outContent));
         }
 
-        testRanker(_dataFile, _modelFile, _rankFile, 6, "ndcg@4");
+        testRanker(_dataFile, _modelFile, _rankFile, rnum, "ndcg@4");
         return outContent.toString();
     }
 
     @Test
-    public void testFeatureStrength() throws IOException {
+    public void testLambdaMARTFeatureStrength() throws IOException {
         _dataFile = new TmpFile();
         try (PrintWriter out = _dataFile.getWriter()) {
             out.println("## LambdaMART ");
@@ -49,7 +49,28 @@ public class FeatureStrengthTest extends RankyTest {
             out.println("0 qid:1 1:0.0 2:1    # P7");
             out.println("0 qid:1 1:0.0 2:1    # P8");
         }
-        String stdOut = runLambdaMart(true);
+        String stdOut = runAndCaptureRanker(6, true);
+        String ftrImpacts = stdOut.substring(stdOut.indexOf("FEATURE IMPACTS"));
+        // we expect "Feature 1" to be a higher impact than feature 2, ensure it comes first
+        assert(ftrImpacts.indexOf("Feature 1") < ftrImpacts.indexOf("Feature 2"));
+
+    }
+
+    @Test
+    public void testRandomForestFeatureStrength() throws IOException {
+        _dataFile = new TmpFile();
+        try (PrintWriter out = _dataFile.getWriter()) {
+            out.println("## LambdaMART ");
+            out.println("4 qid:1 1:100.0 2:1  # P1");
+            out.println("4 qid:1 1:100.0 2:1  # P2 ");
+            out.println("4 qid:1 1:100.0 2:1  # P3");
+            out.println("4 qid:1 1:100.0 2:1  # P4");
+            out.println("0 qid:1 1:0.0 2:1    # P5");
+            out.println("0 qid:1 1:0.0 2:1    # P6");
+            out.println("0 qid:1 1:0.0 2:1    # P7");
+            out.println("0 qid:1 1:0.0 2:1    # P8");
+        }
+        String stdOut = runAndCaptureRanker(8, true);
         String ftrImpacts = stdOut.substring(stdOut.indexOf("FEATURE IMPACTS"));
         // we expect "Feature 1" to be a higher impact than feature 2, ensure it comes first
         assert(ftrImpacts.indexOf("Feature 1") < ftrImpacts.indexOf("Feature 2"));

--- a/test/ciir/umass/edu/eval/RankyTest.java
+++ b/test/ciir/umass/edu/eval/RankyTest.java
@@ -1,0 +1,70 @@
+package ciir.umass.edu.eval;
+
+import ciir.umass.edu.learning.DataPoint;
+import ciir.umass.edu.utilities.FileUtils;
+import ciir.umass.edu.utilities.TmpFile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by doug on 7/1/17.
+ */
+public class RankyTest {
+    protected void testRanker(TmpFile dataFile, TmpFile modelFile, TmpFile rankFile, int rnum, String measure) {
+        System.err.println("Test Ranker: " + rnum);
+
+        synchronized (DataPoint.class) {
+            Evaluator.main(new String[]{
+                    "-train", dataFile.getPath(),
+                    "-metric2t", measure,
+                    "-ranker", Integer.toString(rnum),
+                    "-frate", "1.0",
+                    "-bag", "10",
+                    "-round", "10",
+                    "-epoch", "10",
+                    "-save", modelFile.getPath()});
+        }
+
+        synchronized (DataPoint.class) {
+            Evaluator.main(new String[]{
+                    "-rank", dataFile.getPath(),
+                    "-load", modelFile.getPath(),
+                    "-indri", rankFile.getPath()
+            });
+        }
+
+        int pRank = Integer.MAX_VALUE;
+        int nRank = Integer.MAX_VALUE;
+
+        String trecrun = FileUtils.read(rankFile.getPath(), "UTF-8");
+        for (String line : trecrun.split("\n")) {
+            try {
+                String[] row = line.split("\\s+");
+                //assertEquals("x", row[0]); // qid
+                assertEquals("Q0", row[1]); // unused
+                String dname = row[2];
+                int rank = Integer.parseInt(row[3]);
+                double score = Double.parseDouble(row[4]);
+                //assertEquals("ranklib", row[5]);
+
+                assertFalse(Double.isNaN(score));
+                assertTrue(Double.isFinite(score));
+                assert (rank > 0);
+
+                if (dname.startsWith("P")) {
+                    pRank = Math.min(rank, pRank);
+                } else {
+                    nRank = Math.min(rank, nRank);
+                }
+
+                assertTrue(pRank < nRank);
+                assertEquals(1, pRank);
+            } catch (AssertionError aerr) {
+                throw new RuntimeException(line, aerr);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Problem: you throw a bunch of features (i.e. ES queries) at Ranklib, and you see an answer "spit out" without any understanding which features had the impact. Knowing which features have the most impact is very important: we don't want to wast resources running Elasticsearch queries we don't need at search time!

So this PR adds: 
- In verbose mode, Reports after training which features had the most impact on reducing error for LambdaMART models
- Various newbie commenting the crap out of stuff to help me understand LambdaMART training