### PR TITLE
Migrate release process to Sonatype Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Tag and publish a release
+
+# Mirrors the elasticsearch-learning-to-rank release flow, adapted for this Maven project.
+# Push a tag like v0.3.0 (matching <version> in pom.xml) to cut a release.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set release version name
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      # Imports the GPG key and writes a settings.xml whose `sonatype` server (matching
+      # distributionManagement in pom.xml) reads credentials from the env vars below.
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+          server-id: sonatype
+          server-username: CENTRAL_PORTAL_TOKEN_USERNAME
+          server-password: CENTRAL_PORTAL_TOKEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      # `deploy` runs the verify phase (GPG signs the jar + sources + javadoc) and uploads
+      # the signed artifacts to the Central Portal OSSRH staging API.
+      - name: Build, sign and deploy to Central Portal staging
+        run: mvn --batch-mode clean deploy
+        env:
+          CENTRAL_PORTAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_PORTAL_TOKEN_USERNAME }}
+          CENTRAL_PORTAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_PORTAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASS }}
+
+      # Promotes the staged com.o19s deployment so the Central Portal picks it up for
+      # publishing to Maven Central. Same endpoint ES LTR uses.
+      - name: Trigger upload of staged repository
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.o19s'
+          method: 'POST'
+          bearerToken: ${{ secrets.MAVEN_CENTRAL_BEARER_TOKEN }}
+          preventFailureOnNoResponse: 'true'
+
+      - name: Create GitHub release with jar
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          name: Release ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false
+          files: target/RankyMcRankFace-*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.o19s</groupId>
   <artifactId>RankyMcRankFace</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
 
   <packaging>jar</packaging>
   <name>RankyMcRankFace</name>
@@ -47,11 +47,17 @@
     </dependency>
   </dependencies>
 
+  <!--
+    Legacy OSSRH (oss.sonatype.org) was shut down on 2025-06-30. Publishing now goes
+    through the Sonatype Central Portal. We use its OSSRH-compatibility staging API so the
+    existing Maven deploy flow keeps working; the release workflow then triggers the upload
+    of the staged com.o19s repository to Maven Central.
+  -->
   <distributionManagement>
     <repository>
       <id>sonatype</id>
-      <name>Sonatype</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      <name>Central Portal (OSSRH Staging API)</name>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 
@@ -120,6 +126,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.2.7</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -127,6 +134,13 @@
             <goals>
               <goal>sign</goal>
             </goals>
+            <configuration>
+              <!-- Non-interactive signing in CI; passphrase comes from MAVEN_GPG_PASSPHRASE. -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Legacy OSSRH (oss.sonatype.org) was shut down on 2025-06-30, so the previous publish target no longer works. Mirror the elasticsearch-learning- to-rank release flow (same com.o19s namespace) for this Maven project.

- pom.xml: repoint distributionManagement to the Central Portal OSSRH staging API endpoint; bump version 0.2.0 -> 0.3.0; pin maven-gpg-plugin to 3.2.7 with loopback pinentry for non-interactive CI signing.
- Add .github/workflows/release.yml: tag-triggered (v*.*.*) workflow that signs and deploys to the Central Portal staging API, triggers upload of the staged com.o19s repository, and creates a GitHub release with the jar.

Secrets referenced were added to this Github repository.