### PR TITLE
Fix release workflow tag trigger to match X.Y.Z convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,12 @@
 name: Tag and publish a release
 
 # Mirrors the elasticsearch-learning-to-rank release flow, adapted for this Maven project.
-# Push a tag like v0.3.0 (matching <version> in pom.xml) to cut a release.
+# Push a tag matching <version> in pom.xml to cut a release, e.g. 0.3.0.
 
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   release:


### PR DESCRIPTION
The release workflow triggered only on `v`-prefixed tags (`v*.*.*`), but this repo tags releases without a prefix (`0.1.0`, `0.3.0`). The `0.3.0` tag therefore never fired a release.

This changes the trigger to `[0-9]+.[0-9]+.[0-9]+` to match the repo's existing convention.

## After merge
The existing `0.3.0` tag points at a commit with the old trigger, so it must be re-created on the merge commit to fire the release:

```
git push origin :refs/tags/0.3.0        # delete remote tag
git tag -d 0.3.0                         # delete local tag
git tag 0.3.0 origin/master              # re-tag on the fixed commit
git push origin 0.3.0                    # triggers the release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)